### PR TITLE
Add system includes on C++ flags to help SLP

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -12,7 +12,7 @@ BUILD_DIR=linux-build
 if [ -d "$BUILD_DIR" ]; then rm -Rf $BUILD_DIR; fi
 
 # Create folder, move inside, build and run
-mkdir -pv $BUILD_DIR && cd $BUILD_DIR && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1 && make run
+mkdir -pv $BUILD_DIR && cd $BUILD_DIR && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_FLAGS="-isystem /usr/include/c++/11/ -isystem /usr/include/x86_64-linux-gnu/c++/11/" && make run
 
 # NOTE: tell cmake to export compile commands and make the syslink is not really needed
 # I use it to help the SLP (Server Language Protocol) to find the included headers files

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -12,7 +12,7 @@ BUILD_DIR=linux-build
 if [ -d "$BUILD_DIR" ]; then rm -Rf $BUILD_DIR; fi
 
 # Create folder, move inside, build and run
-mkdir -pv $BUILD_DIR && cd $BUILD_DIR && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_FLAGS="-isystem /usr/include/c++/11/ -isystem /usr/include/x86_64-linux-gnu/c++/11/" && make run
+mkdir -pv $BUILD_DIR && cd $BUILD_DIR || exit && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_FLAGS="-isystem /usr/include/c++/11/ -isystem /usr/include/x86_64-linux-gnu/c++/11/" && make run
 
 # NOTE: tell cmake to export compile commands and make the syslink is not really needed
 # I use it to help the SLP (Server Language Protocol) to find the included headers files

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -4,7 +4,7 @@ set -x # echo commands
 SCRIPT_PATH="${0%/*}"
 
 # No matter where you are, the script always runs in this directory
-cd $SCRIPT_PATH || exit
+cd "$SCRIPT_PATH" || exit 1
 
 BUILD_DIR=linux-build
 

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -4,7 +4,7 @@ set -x # echo commands
 SCRIPT_PATH="${0%/*}"
 
 # No matter where you are, the script always runs in this directory
-cd $SCRIPT_PATH
+cd $SCRIPT_PATH || exit
 
 BUILD_DIR=linux-build
 
@@ -12,7 +12,7 @@ BUILD_DIR=linux-build
 if [ -d "$BUILD_DIR" ]; then rm -Rf $BUILD_DIR; fi
 
 # Create folder, move inside, build and run
-mkdir -pv $BUILD_DIR && cd $BUILD_DIR || exit && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_FLAGS="-isystem /usr/include/c++/11/ -isystem /usr/include/x86_64-linux-gnu/c++/11/" && make run
+mkdir -pv $BUILD_DIR && cd $BUILD_DIR && cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_FLAGS="-isystem /usr/include/c++/11/ -isystem /usr/include/x86_64-linux-gnu/c++/11/" && make run
 
 # NOTE: tell cmake to export compile commands and make the syslink is not really needed
 # I use it to help the SLP (Server Language Protocol) to find the included headers files


### PR DESCRIPTION
Add system includes on C++ flags to help SLP (Server Language Protocol) with IntelliSense

CMake export compile commands to `compile_commands.json`, but it doesn't add system includes by default,
so passing "-isystem /path/to/include/dir" fix the issue. To know which flags to add, run `gcc -H srcFile.cpp`